### PR TITLE
update the TravisCI config and NPM package info to match the NodeJS versions actually supported by the current code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - node
-  - 0.10
-  - 0.11
-  - 0.12
   - 4
   - 5
   - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
----
+sudo: false
 language: node_js
 node_js:
-- '6'
+  - node
+  - 0.10
+  - 0.11
+  - 0.12
+  - 4
+  - 5
+  - 6
+  - 7

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "author": "Florent Jaby <florent.jaby@gmail.com>",
   "license": "MIT",
   "gitHead": "635fe6e77f2212d01853d09dc602efcb1766dcf3",
+  "engines": {
+    "node": ">=4.0"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "istanbul": "^0.4.4",


### PR DESCRIPTION
(requires #4 to pass CI)

This pullreq is meant to get node-stream-sink completely up-to-date (and suitable for dependent packages such as my live_server fork to pass **their** TravisCI/other tests).